### PR TITLE
chore: release v1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8] - 2026-07-12
+
+### 📦️ Dependencies
+
+- **(deps)** Upgrade github.com/powerman/structlog to v0.9.0 by @powerman in [ca411a3]
+
+[1.1.8]: https://github.com/powerman/gh-make-labels/compare/v1.1.7..v1.1.8
+[ca411a3]: https://github.com/powerman/gh-make-labels/commit/ca411a3329784d0b4aa1db2bf34681f344f93f30
+
 ## [1.1.7] - 2026-04-07
 
 ### 📦️ Dependencies


### PR DESCRIPTION

### 📦️ Dependencies

- **(deps)** Upgrade github.com/powerman/structlog to v0.9.0 by @powerman in [ca411a3]

[1.1.8]: https://github.com/powerman/gh-make-labels/compare/v1.1.7..v1.1.8
[ca411a3]: https://github.com/powerman/gh-make-labels/commit/ca411a3329784d0b4aa1db2bf34681f344f93f30